### PR TITLE
Document EXPLICATION as commentary

### DIFF
--- a/docs/קישורים-וכותרות.md
+++ b/docs/קישורים-וכותרות.md
@@ -236,10 +236,9 @@ SUMMARY           SIFREI_MITZVOT     ESSAY
 | `PARSHANUT` | פרשנות כללית |
 | `DIBUR_HAMATCHIL` | קישור לפי דיבור המתחיל (ד"ה) |
 | `ELUCIDATION` | ביאור נרחב (כמו "עין איה") |
+| `EXPLICATION` | ביאור / פרשנות |
 
 הפונקציה הקובעת באפליקציה: `LinkTypes.isDependentTextLink(connectionType)` — מחזירה `true` לסוגים הנ"ל.
-
-> **הערה:** `EXPLICATION` קיים ב־enum של SeforimLibrary אך **אינו** נכלל ב־`dependentTextTypes` של האפליקציה — הוא יסווג כקישור/הפניה (פאנל הקישורים), לא כמפרש. אל תסתמכו עליו כדי שספר יוצג בפאנל המפרשים.
 
 #### סוגי קישור — `isReferenceLikeLink`
 
@@ -260,7 +259,6 @@ SUMMARY           SIFREI_MITZVOT     ESSAY
 | `SUMMARY` | סיכום |
 | `SIFREI_MITZVOT` | ספרי מצוות |
 | `ESSAY` | מאמר / חיבור עצמאי |
-| `EXPLICATION` | ביאור/פרשנות (קיים ב־enum אך **אינו** מוצג כמפרש באפליקציה) |
 | `OTHER` | אחר / לא מסווג |
 
 הפונקציה הקובעת: `LinkTypes.isReferenceLikeLink(connectionType)` — מחזירה `true` לכל מה שאינו `SOURCE` ואינו בקבוצת המפרשים.
@@ -290,7 +288,7 @@ SUMMARY           SIFREI_MITZVOT     ESSAY
 | `parshanut` | `PARSHANUT` | |
 | `dibur_hamatchil` | `DIBUR_HAMATCHIL` | |
 | `elucidation` | `ELUCIDATION` | ביאור נרחב |
-| `explication` | `EXPLICATION` | ביאור/פרשנות — **לא** נופל ל־`OTHER`, אך **אינו** מוצג כמפרש באפליקציה (יוצג בפאנל הקישורים) |
+| `explication` | `EXPLICATION` | ביאור / פרשנות |
 
 #### ממופים לסוגי קישור
 
@@ -334,9 +332,9 @@ SUMMARY           SIFREI_MITZVOT     ESSAY
 - `isReferenceLikeLink(type)` → מופיע בפאנל הקישורים
 
 כדי שקישור יופיע **כמפרש** — השתמשו **בדיוק** באחד מהערכים:
-`commentary`, `super_commentary`, `targum`, `midrash`, `parshanut`, `dibur_hamatchil`, `elucidation`.
+`commentary`, `super_commentary`, `targum`, `midrash`, `parshanut`, `dibur_hamatchil`, `elucidation`, `explication`.
 
-כל ערך אחר (כולל `explication`, `allusion`, `linker`, `essay`, `law` וכו') יופיע **בפאנל הקישורים**, לא בפאנל המפרשים.
+כל ערך אחר (למשל `allusion`, `linker`, `essay`, `law`) יופיע **בפאנל הקישורים**, לא בפאנל המפרשים.
 
 
 ---


### PR DESCRIPTION
## מה השתנה

עודכן תיעוד סוגי הקישור כך ש־`EXPLICATION` מסווג כמפרש.

## למה

האפליקציה מסווגת כעת את הסוג הזה כטקסט תלוי; התיעוד משקף את ההתנהגות בפועל.

## בדיקה

`git diff --check`